### PR TITLE
add output parameters to facilitate mapping

### DIFF
--- a/MONTSERRAT_BIRD_MONITORING_Nimble.R
+++ b/MONTSERRAT_BIRD_MONITORING_Nimble.R
@@ -327,7 +327,7 @@ inits.trend <- list(#N = Nst,
 ####   DEFINE RUN SETTINGS AND OUTPUT DATA----     ################################
 
 # Define parameters to be monitored
-parameters.trend <- c("fit", "fit.new","trend","trend2","totalN","anndet")  #
+parameters.trend <- c("fit", "fit.new","trend","trend2","totalN","anndet","N")  #
 
 
 # MCMC settings


### PR DESCRIPTION
to facilitate a map representation of abundance, add "N" (the site-specific abundance estimates per point) to the output reported from each model for each species